### PR TITLE
Try fixing permissions stuff

### DIFF
--- a/compile
+++ b/compile
@@ -2,4 +2,4 @@
 
 URL="github.com/letsblockit/letsblockit/cmd/render@latest"
 
-go run $URL src/main.yml > build/main.txt
+go run "$URL" "src/main.yml" > "build/main.txt"


### PR DESCRIPTION
The changes in the file are completely irrelevant. We are trying to fix the permissions on the `compile` file by running `git update-index --chmod=+x compile`.  If that works we don't need to set the permission each time inside of our GitHub workflow. 